### PR TITLE
refactor(IProjectioneditor.getSubProjectionBySubjectId): rename/alias to filterProjectionBySubjectId

### DIFF
--- a/src/ProjectionEditor/IProjectionEditor.ts
+++ b/src/ProjectionEditor/IProjectionEditor.ts
@@ -8,8 +8,11 @@ import type { IProjectableSubjectDictionary } from "../ProjectableSubjectDiction
 export interface IProjectionEditor {
   addSubject(projection: TProjectionItemProperties): string;
 
+  filterProjectionBySubjectId(subjectId: string): TProjectionDictionary;
+
   getProjectableSubjectsDictionary(): IProjectableSubjectDictionary;
 
+  // deprecated - use 'filterProjectionBySubjectId'
   getSubProjectionBySubjectId(subjectId: string): TProjectionDictionary;
 
   getKeys(): string[];

--- a/src/ProjectionEditor/ProjectionEditor.test.ts
+++ b/src/ProjectionEditor/ProjectionEditor.test.ts
@@ -116,7 +116,8 @@ describe("Projection", () => {
       expect(projectables.constructor.name).toBe("ProjectableSubjectDictionary");
     }); //
   });
-  describe(".getSubProjectionBySubjectId", () => {
+
+  describe(".filterProjectionBySubjectId", () => {
     it("Should return subset projection, only subject with given subjectId", () => {
       // set-up
       const projection = ProjectionSimple.fromFlatFile(
@@ -125,7 +126,7 @@ describe("Projection", () => {
       );
 
       // exercise
-      const subProjection = projection.getSubProjectionBySubjectId("firstname");
+      const subProjection = projection.filterProjectionBySubjectId("firstname");
 
       // post conditions
       expect(Object.keys(subProjection).length).toBe(1);
@@ -140,7 +141,7 @@ describe("Projection", () => {
       );
 
       // exercise
-      const subProjection = projection.getSubProjectionBySubjectId("DOES_NOT_EXIST");
+      const subProjection = projection.filterProjectionBySubjectId("DOES_NOT_EXIST");
 
       // post conditions
       expect(Object.keys(subProjection).length).toBe(0);

--- a/src/ProjectionEditor/ProjectionSimple.ts
+++ b/src/ProjectionEditor/ProjectionSimple.ts
@@ -33,12 +33,8 @@ export class ProjectionSimple implements IProjectionEditor {
     return projectionSubjectId;
   }
 
-  getProjectableSubjectsDictionary(): IProjectableSubjectDictionary {
-    return this._projectableSubjects;
-    //    return cloneDeep(this._projectableSubjects);
-  }
-
-  getSubProjectionBySubjectId(subjectId: string): TProjectionDictionary {
+  filterProjectionBySubjectId(subjectId: string): TProjectionDictionary {
+    // a subset projection that contains only given subjectId
     const subjects: TProjectionDictionary = {};
     Object.entries(this._projections).forEach(([projectionKey, subject]) => {
       if (subjectId === subject.subjectId) {
@@ -46,6 +42,16 @@ export class ProjectionSimple implements IProjectionEditor {
       }
     });
     return subjects;
+  }
+
+  getProjectableSubjectsDictionary(): IProjectableSubjectDictionary {
+    return this._projectableSubjects;
+    //    return cloneDeep(this._projectableSubjects);
+  }
+
+  getSubProjectionBySubjectId(subjectId: string): TProjectionDictionary {
+    // a subset projection that contains only given subjectId
+    return this.filterProjectionBySubjectId(subjectId);
   }
 
   getKeys(): string[] {


### PR DESCRIPTION
`getSubProjectionBySubjectId` poorly named. Changed/Aliased to something more indicative of its intent.

fix #15